### PR TITLE
allow connection via a connection string as an alternative to a dsn

### DIFF
--- a/R/ODBCDriver.R
+++ b/R/ODBCDriver.R
@@ -1,5 +1,5 @@
 #' ODBCDriver and methods.
-#' 
+#'
 #' An ODBC driver implementing the R database (DBI) API.
 #' This class should always be initialized with the \code{ODBC()} function.
 #' It returns an object that allows you to connect to ODBC.
@@ -12,7 +12,7 @@ setClass("ODBCDriver", contains = "DBIDriver")
 #'
 #' This driver is for implementing the R database (DBI) API.
 #' This class should always be initialized with the \code{ODBC()} function.
-#' ODBC driver does nothing for ODBC connection. It just exists for S4 class compatibility with DBI package. 
+#' ODBC driver does nothing for ODBC connection. It just exists for S4 class compatibility with DBI package.
 #'
 #' @export
 #' @examples
@@ -33,28 +33,36 @@ setMethod("dbUnloadDriver", "ODBCDriver", function(drv, ...) {TRUE})
 #' Connect/disconnect to a ODBC data source
 #'
 #' These methods are straight-forward implementations of the corresponding generic functions.
-#' 
+#'
 #' @param drv an object of class ODBCDriver
 #' @param dsn Data source name you defined by ODBC data source administrator tool.
 #' @param user User name to connect as.
 #' @param password Password to be used if the DSN demands password authentication.
+#' @param connection Connection string to use to connect to the ODBC database server (as per \code{odbcDriverConnect}, e.g. 'driver={SQL Server};server=mysqlhost;database=mydbname;trusted_connection=true')
 #' @param ... Other parameters passed on to methods
 #' @export
 #' @examples
 #' \dontrun{
 #' # Connect to a ODBC data source
 #' con <- dbConnect(RODBCDBI::ODBC(), dsn="test")
+#' # or using a connection string
+#' con <- dbConnect(RODBCDBI::ODBC(),
+#'   connection="driver={SQL Server};server=mysqlhost;
+#'   database=mydbname;trusted_connection=true")
 #' # Always cleanup by disconnecting the database
 #' #' dbDisconnect(con)
 #' }
 setMethod(
-  "dbConnect", 
-  "ODBCDriver", 
-  function(drv, dsn, user = NULL, password = NULL, ...){
+  "dbConnect",
+  "ODBCDriver",
+  function(drv, dsn, user = NULL, password = NULL, connection, ...){
     uid <- if(is.null(user)) "" else user
     pwd <- if(is.null(password)) "" else password
-    connection <- odbcConnect(dsn, uid, pwd, ...)
-    new("ODBCConnection", odbc=connection)
+    if (missing(dsn) && !missing(connection))
+        con <- odbcDriverConnect(connection, ...)
+    else
+        con <- odbcConnect(dsn, uid, pwd, ...)
+    new("ODBCConnection", odbc=con)
   }
 )
 
@@ -63,9 +71,9 @@ setMethod(
 setMethod("dbIsValid", "ODBCDriver", function(dbObj) {TRUE})
 
 #' Get ODBCDriver metadata.
-#' 
+#'
 #' Nothing to do for ODBCDriver case
-#' 
+#'
 #' @rdname ODBCDriver-class
 #' @export
 setMethod("dbGetInfo", "ODBCDriver", function(dbObj, ...) {NULL})

--- a/man/dbConnect-ODBCDriver-method.Rd
+++ b/man/dbConnect-ODBCDriver-method.Rd
@@ -6,7 +6,7 @@
 \title{Connect/disconnect to a ODBC data source}
 \usage{
 \S4method{dbConnect}{ODBCDriver}(drv, dsn, user = NULL, password = NULL,
-  ...)
+  connection, ...)
 }
 \arguments{
 \item{drv}{an object of class ODBCDriver}
@@ -17,6 +17,8 @@
 
 \item{password}{Password to be used if the DSN demands password authentication.}
 
+\item{connection}{Connection string to use to connect to the ODBC database server (as per \code{odbcDriverConnect}, e.g. 'driver={SQL Server};server=mysqlhost;database=mydbname;trusted_connection=true')}
+
 \item{...}{Other parameters passed on to methods}
 }
 \description{
@@ -26,6 +28,10 @@ These methods are straight-forward implementations of the corresponding generic 
 \dontrun{
 # Connect to a ODBC data source
 con <- dbConnect(RODBCDBI::ODBC(), dsn="test")
+# or using a connection string
+con <- dbConnect(RODBCDBI::ODBC(),
+  connection="driver={SQL Server};server=mysqlhost;
+  database=mydbname;trusted_connection=true")
 # Always cleanup by disconnecting the database
 #' dbDisconnect(con)
 }


### PR DESCRIPTION
Very minor addition to allow dbConnect to take a connection string, rather than a dsn. e.g.
con <- dbConnect(RODBCDBI::ODBC(),connection="driver={SQL Server};server=my_server_name;trusted_connection=true")

Have tested manually, and it seems to work fine. I can't think of an automated test to add to the testthat collection, because it needs a db server to connect to.
